### PR TITLE
docs: minor typo fix

### DIFF
--- a/retries-and-saga/README.md
+++ b/retries-and-saga/README.md
@@ -21,7 +21,7 @@ order.
 
 ### Naive implementation
 
-In a naive implementation, you might have you have 2 services,
+In a naive implementation, you might have 2 services,
 `OrderService` to receive orders and `CustomerService` to manage customer's credit:
 
 ![Naive implementation](image1.png)


### PR DESCRIPTION
There is a very minor typo in the documentation and also the [Google blog for the workflow retry example](https://cloud.google.com/blog/topics/developers-practitioners/implementing-saga-pattern-workflows).