### PR TITLE
Add sample for executing Cloud Run jobs from Workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ that explains Workflows.
 * [Retries and Saga Pattern in Workflows](retries-and-saga)
 * [Long running containers with Workflows and Compute Engine](long-running-container)
 * [Workflows state management with Firestore](state-management-firestore)
+* [Execute a Cloud Run job using Workflows](cloud-run-jobs)
 * [Take screenshots of webpages with Cloud Run jobs, Workflows and Eventarc](screenshot-jobs)
 * Batch and Workflows samples
   * [Batch - simple container](https://github.com/GoogleCloudPlatform/batch-samples/tree/main/busybox)

--- a/cloud-run-jobs/README.md
+++ b/cloud-run-jobs/README.md
@@ -1,0 +1,85 @@
+# Execute a Cloud Run job using Workflows
+
+> **Note:** The Cloud Run jobs feature is currently in the *preview* release
+> stage.
+
+This sample demonstrates how to execute a Cloud Run job from a workflow.
+
+## Create a Cloud Run job
+
+This sample uses the Cloud Run jobs
+[parallel processing](https://github.com/GoogleCloudPlatform/jobs-demos/tree/main/parallel-processing)
+demo.
+
+Clone the Cloud Run jobs demo app repository:
+
+```sh
+git clone https://github.com/GoogleCloudPlatform/jobs-demos.git
+```
+
+Change to the directory that contains the sample code:
+
+```sh
+cd jobs-demos/parallel-processing
+```
+
+Create the Cloud Run job by running the deployment script:
+
+```sh
+./deploy-parallel-job.sh
+```
+
+The job processes data from an input file in Cloud Storage in the location
+`gs://input-[PROJECT_ID]/input_file.txt`.
+
+## Deploy the workflow
+
+Create a `workflow.yaml` file with the provided
+[workflow definition](workflow.yaml).
+
+The sample workflow accepts a Cloud Storage event as a parameter and uses
+the event to determine whether to execute the Cloud Run job. If the
+Cloud Storage object specified in the event is the input data file used by
+the job, the workflow executes the job. Otherwise, the workflow terminates.
+
+Deploy the workflow:
+
+```sh
+gcloud workflows deploy cloud-run-job-workflow \
+    --location=us-central1 \
+    --source=workflow.yaml
+```
+
+## Create a trigger
+
+Create an Eventarc trigger that executes the workflow whenever a file is
+uploaded or overwritten in the Cloud Storage bucket containing the input data
+file:
+
+```sh
+export PROJECT_ID=$(gcloud config get project)
+export PROJECT_NUMBER=$(gcloud projects describe $PROJECT_ID --format="value(projectNumber)")
+gcloud eventarc triggers create cloud-run-job-workflow-trigger \
+    --location=us \
+    --destination-workflow=cloud-run-job-workflow  \
+    --destination-workflow-location=us-central1 \
+    --event-filters="type=google.cloud.storage.object.v1.finalized" \
+    --event-filters="bucket=input-$PROJECT_ID" \
+    --service-account="$PROJECT_NUMBER-compute@developer.gserviceaccount.com"
+```
+
+## Trigger the workflow
+
+Test the end-to-end system by updating the input data file in Cloud Storage:
+
+```sh
+base64 /dev/urandom | head -c 100000 >input_file.txt
+gsutil cp input_file.txt gs://input-$PROJECT_ID/input_file.txt
+```
+
+Confirm that the Cloud Run job ran as expected by viewing the job executions:
+
+```sh
+gcloud beta run jobs executions list --job=parallel-job
+```
+

--- a/cloud-run-jobs/workflow.yaml
+++ b/cloud-run-jobs/workflow.yaml
@@ -1,0 +1,26 @@
+main:
+    params: [event]
+    steps:
+        - init:
+            assign:
+                - project_id: ${sys.get_env("GOOGLE_CLOUD_PROJECT_ID")}
+                - event_bucket: ${event.data.bucket}
+                - event_object: ${event.data.name}
+                - target_bucket: ${"input-" + project_id}
+                - target_object: input_file.txt
+                - job_name: parallel-job
+                - job_location: us-central1
+        - check_input_object:
+            switch:
+                - condition: ${(event_bucket == target_bucket) and (event_object == target_object)}
+                  next: run_job
+                - condition: true
+                  next: end
+        - run_job:
+            call: googleapis.run.v1.namespaces.jobs.run
+            args:
+                name: ${"namespaces/" + project_id + "/jobs/" + job_name}
+                location: ${job_location}
+            result: job_execution
+        - finish:
+            return: ${job_execution}


### PR DESCRIPTION
This sample demonstrates how to use the Cloud Run Admin API connector to execute a Cloud Run job from a workflow.

It uses the existing Cloud Run jobs [parallel-processing](https://github.com/GoogleCloudPlatform/jobs-demos/tree/main/parallel-processing) demo, and adds an Eventarc trigger and some logic within a workflow to execute the Cloud Run job whenever its input data file is updated.

This sample will also be used in a tutorial in the Workflows documentation.