### PR TITLE
fix: project argument in cloud storage bucket creation

### DIFF
--- a/batch-translation/workflow.yaml
+++ b/batch-translation/workflow.yaml
@@ -23,8 +23,7 @@ main:
   - createOutputBucket:
         call: googleapis.storage.v1.buckets.insert
         args:
-          query:
-            project: ${projectId}
+          project: ${projectId}
           body:
             name: ${outputBucketName}
   - batchTranslateText:


### PR DESCRIPTION
This pull request corrects the project argument in the Google Cloud Storage bucket creation method. 

Changed from `query.project` to `project`, as per [Cloud Workflows documentation](https://cloud.google.com/workflows/docs/reference/googleapis/storage/v1/buckets/insert).